### PR TITLE
[TASK] Remove auto-generated columns from ext_tables.sql

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -2,9 +2,6 @@
 # Table structure for table 'tx_pwcomments_domain_model_comment'
 #
 CREATE TABLE tx_pwcomments_domain_model_comment (
-	uid int(11) NOT NULL auto_increment,
-	pid int(11) DEFAULT '0' NOT NULL,
-
 	entry_uid int(11) unsigned DEFAULT '0' NOT NULL,
 	parent_comment int(11) unsigned DEFAULT '0' NOT NULL,
 	orig_pid int(11) unsigned DEFAULT '0' NOT NULL,
@@ -16,58 +13,15 @@ CREATE TABLE tx_pwcomments_domain_model_comment (
 	message text,
 	votes int(11) unsigned DEFAULT '0' NOT NULL,
 	terms_accepted int(11) unsigned DEFAULT '0' NOT NULL,
-
-	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
-	crdate int(11) unsigned DEFAULT '0' NOT NULL,
-	deleted tinyint(4) unsigned DEFAULT '0' NOT NULL,
-	hidden tinyint(4) unsigned DEFAULT '0' NOT NULL,
-
-	t3ver_oid int(11) DEFAULT '0' NOT NULL,
-	t3ver_id int(11) DEFAULT '0' NOT NULL,
-	t3ver_wsid int(11) DEFAULT '0' NOT NULL,
-	t3ver_label varchar(30) DEFAULT '' NOT NULL,
-	t3ver_state tinyint(4) DEFAULT '0' NOT NULL,
-	t3ver_stage tinyint(4) DEFAULT '0' NOT NULL,
-	t3ver_count int(11) DEFAULT '0' NOT NULL,
-	t3ver_tstamp int(11) DEFAULT '0' NOT NULL,
-	t3ver_move_id int(11) DEFAULT '0' NOT NULL,
-	t3_origuid int(11) DEFAULT '0' NOT NULL,
-
-	sys_language_uid int(11) DEFAULT '0' NOT NULL,
-	l18n_parent int(11) DEFAULT '0' NOT NULL,
-	l18n_diffsource mediumblob NOT NULL,
-
-	PRIMARY KEY (uid),
-	KEY parent (pid)
 );
 
 #
 # Table structure for table 'tx_pwcomments_domain_model_vote'
 #
 CREATE TABLE tx_pwcomments_domain_model_vote (
-	uid int(11) NOT NULL auto_increment,
-	pid int(11) DEFAULT '0' NOT NULL,
-
 	orig_pid int(11) unsigned DEFAULT '0' NOT NULL,
 	type int(11) unsigned DEFAULT '1' NOT NULL,
 	author int(11) unsigned DEFAULT '0' NOT NULL,
 	author_ident tinytext,
 	comment int(11) unsigned DEFAULT '0' NOT NULL,
-
-	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
-	crdate int(11) unsigned DEFAULT '0' NOT NULL,
-
-	t3ver_oid int(11) DEFAULT '0' NOT NULL,
-	t3ver_id int(11) DEFAULT '0' NOT NULL,
-	t3ver_wsid int(11) DEFAULT '0' NOT NULL,
-	t3ver_label varchar(30) DEFAULT '' NOT NULL,
-	t3ver_state tinyint(4) DEFAULT '0' NOT NULL,
-	t3ver_stage tinyint(4) DEFAULT '0' NOT NULL,
-	t3ver_count int(11) DEFAULT '0' NOT NULL,
-	t3ver_tstamp int(11) DEFAULT '0' NOT NULL,
-	t3ver_move_id int(11) DEFAULT '0' NOT NULL,
-	t3_origuid int(11) DEFAULT '0' NOT NULL,
-
-	PRIMARY KEY (uid),
-	KEY parent (pid)
 );


### PR DESCRIPTION
Auto-generated columns should be omitted from being defined in ext_tables.sql according https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/FileStructure/ExtTablesSql.html#auto-generated-db-structure

Leaving them there, can lead to errors such as TYPO3 complaining over non-existing columns (t3ver_oid i.e.), for there seems to be a discrepancy off to when columns from ext_tables.sql are being compared against those defined in TCA.